### PR TITLE
Be compatible with non-default *PRINT-CASE*.

### DIFF
--- a/format.lisp
+++ b/format.lisp
@@ -47,7 +47,8 @@
                      finally (return (format nil "~{~<~%~1,76:;~A~>~^ ~}"
                                              words))))
          (intern-symbol (string &rest args)
-           (intern (apply #'format nil string args) "BINASCII")))
+           (intern (with-standard-io-syntax (apply #'format nil string args))
+                   (find-package '#:binascii))))
     (let ((binascii-name (intern (symbol-name name)))
           (descriptor-fun (intern-symbol "~A-FORMAT-DESCRIPTOR" name))
           (simple-encode-fun (intern-symbol "ENCODE-~A" name))


### PR DESCRIPTION
With `*print-case*` set to `:downcase`, `define-format` produces symbols like `|DECODE-ascii85|`.  This patch fixes this using `with-standard-io-syntax`.

`find-package` makes no difference from the original `"BINASCII"` with `readtable-case` `:upcase` or `:invert`, and two other cases are not supported anyway; but this way it looks more correct.
